### PR TITLE
Remove test target and documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,6 @@ build:
 install:
 	opam exec -- dune install
 
-.PHONY: test
-test:
-	opam exec -- dune build @test/runtest -f
-
 .PHONY: clean
 clean:
 	opam exec -- dune clean

--- a/README.md
+++ b/README.md
@@ -121,14 +121,6 @@ For instance, to run the `confirm.ml` example, you can type:
 dune exec examples/confirm.exe
 ```
 
-### Running Tests
-
-You can test compiled executable with:
-
-```bash
-make test
-```
-
 ### Building documentation
 
 Documentation for the libraries in the project can be generated with:
@@ -159,9 +151,6 @@ The following snippet describes Inquire's repository structure.
 │
 ├── lib/
 |   Source for Inquire's library. Contains Inquire's core functionnalities.
-│
-├── test/
-|   Unit tests and integration tests for Inquire.
 │
 ├── dune-project
 |   Dune file used to mark the root of the project and define project-wide parameters.


### PR DESCRIPTION
There seems to be no `test/` directory despite the documentation mentioning it. Tests were also recently removed from CI in https://github.com/tmattio/inquire/commit/c8b2ebdcd2cd724024b66f609f3c1d77abe6a6fa. This PR removes mentions of tests from the README and also removes the target in the `Makefile`.